### PR TITLE
fix: `_query` should read response in chunks

### DIFF
--- a/aerospace.lua
+++ b/aerospace.lua
@@ -81,7 +81,19 @@ function Aerospace:_query(args, want_json, big)
 	local payload = PAYLOAD_TMPL:format(encode(args))
 	write(self.fd, payload)
 
-	local raw = read(self.fd, big and DEFAULT.EXT_BUF or DEFAULT.MAX_BUF)
+	-- Read all available data from socket in chunks
+    local chunks = {}
+    local chunk_size = big and DEFAULT.EXT_BUF or DEFAULT.MAX_BUF
+    repeat
+        local chunk = read(self.fd, chunk_size)
+        if chunk and #chunk > 0 then
+            table.insert(chunks, chunk)
+        else
+            break
+        end
+    until #chunk < chunk_size  -- Stop when we get a partial chunk (last chunk)
+
+    local raw = table.concat(chunks)
 	local out = stdout(raw)
 	return want_json and decode(out) or out
 end


### PR DESCRIPTION
When having 7 aerospace workspaces including some apps opened, I ran into:

```bash
lua: ./helpers/aerospace.lua:58: Expected value but found unexpected end of string at character 4097               ▇
78%
stack traceback:
    [C]: in function 'cjson.decode'
    ./helpers/aerospace.lua:58: in upvalue 'stdout'
    ./helpers/aerospace.lua:94: in function 'helpers.aerospace._query'
    ./helpers/aerospace.lua:99: in function <./helpers/aerospace.lua:98>
    (...tail calls...)
    ./items/workspaces.lua:202: in main chunk
    [C]: in function 'require'
    ./items/init.lua:3: in main chunk
    [C]: in function 'require'
    ./init.lua:11: in main chunk
    [C]: in function 'require'
    /Users/fgeck/.config/sketchybar/sketchybarrc:23: in main chunk
    [C]: in ?
```

It seems like the buffer size is too small.
Therefore, this PR proposes to read the response in chunks until the response's byte size is smaller than `EXT_BUF`.

For me, after applying the changes the lua api for aerospace works again.